### PR TITLE
feat: Added Qdrant support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,12 @@
             <version>1.65.1</version>
         </dependency>
 
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java-util</artifactId>
+			<version>3.25.5</version>
+		</dependency>
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>1.65.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>1.65.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.16.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,12 @@
         </dependency>
 
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-qdrant</artifactId>
+            <version>${langchain4jVersion}</version>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.16.1</version>

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/constant/Constants.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/constant/Constants.java
@@ -39,6 +39,7 @@ public class Constants {
   public static final String VECTOR_STORE_PINECONE = "PINECONE";
   public static final String VECTOR_STORE_WEAVIATE = "WEAVIATE";
   public static final String VECTOR_STORE_AI_SEARCH = "AI_SEARCH";
+  public static final String VECTOR_STORE_QDRANT = "QDRANT";
 
   public static final String STORE_SCHEMA_METADATA_FIELD_NAME = "metadata";
   public static final String STORE_SCHEMA_VECTOR_FIELD_NAME = "vector";

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/helper/EmbeddingOperationValidator.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/helper/EmbeddingOperationValidator.java
@@ -48,7 +48,8 @@ public class EmbeddingOperationValidator {
               Constants.VECTOR_STORE_CHROMA,
               Constants.VECTOR_STORE_PINECONE,
               Constants.VECTOR_STORE_WEAVIATE,
-              Constants.VECTOR_STORE_AI_SEARCH
+              Constants.VECTOR_STORE_AI_SEARCH,
+              Constants.VECTOR_STORE_QDRANT
             )));
 
     // Weaviate not supported for FILTER_BY_METADATA operation
@@ -60,7 +61,8 @@ public class EmbeddingOperationValidator {
               Constants.VECTOR_STORE_MILVUS,
               Constants.VECTOR_STORE_CHROMA,
               Constants.VECTOR_STORE_PINECONE,
-              Constants.VECTOR_STORE_AI_SEARCH
+              Constants.VECTOR_STORE_AI_SEARCH,
+              Constants.VECTOR_STORE_QDRANT
             )));
 
     EMBEDDING_OPERATION_TYPE_TO_SUPPORTED_VECTOR_STORES.put(Constants.EMBEDDING_OPERATION_TYPE_REMOVE_EMBEDDINGS,

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/helper/EmbeddingOperationValidator.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/helper/EmbeddingOperationValidator.java
@@ -86,7 +86,8 @@ public class EmbeddingOperationValidator {
               Constants.VECTOR_STORE_CHROMA,
               // Constants.VECTOR_STORE_PINECONE, // Do not support GTE with strings.
               // Constants.VECTOR_STORE_WEAVIATE, // Not Supported
-              Constants.VECTOR_STORE_AI_SEARCH
+              Constants.VECTOR_STORE_AI_SEARCH,
+              Constants.VECTOR_STORE_QDRANT
             )));
 
   }

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/helper/provider/VectorStoreProvider.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/helper/provider/VectorStoreProvider.java
@@ -16,13 +16,14 @@ public class VectorStoreProvider implements ValueProvider {
      return ValueBuilder.getValuesFor(
             Constants.VECTOR_STORE_PGVECTOR,
             Constants.VECTOR_STORE_ELASTICSEARCH,
-             Constants.VECTOR_STORE_OPENSEARCH,
+            Constants.VECTOR_STORE_OPENSEARCH,
             Constants.VECTOR_STORE_MILVUS,
             Constants.VECTOR_STORE_CHROMA,
             Constants.VECTOR_STORE_PINECONE,
             Constants.VECTOR_STORE_WEAVIATE,
             Constants.VECTOR_STORE_AI_SEARCH,
-             Constants.VECTOR_STORE_OPENSEARCH
+            Constants.VECTOR_STORE_OPENSEARCH,
+            Constants.VECTOR_STORE_QDRANT
     ); // MuleChainVectorsConstants.VECTOR_STORE_NEO4J
   }
 

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/store/BaseStore.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/store/BaseStore.java
@@ -15,7 +15,8 @@ import org.mule.extension.mulechain.vectors.internal.store.milvus.MilvusStore;
 import org.mule.extension.mulechain.vectors.internal.store.opensearch.OpenSearchStore;
 import org.mule.extension.mulechain.vectors.internal.store.pgvector.PGVectorStore;
 import org.mule.extension.mulechain.vectors.internal.store.pinecone.PineconeStore;
-import org.mule.extension.mulechain.vectors.internal.store.weviate.WeaviateStore;
+import org.mule.extension.mulechain.vectors.internal.store.qdrant.QdrantStore;
+import org.mule.extension.mulechain.vectors.internal.store.weaviate.WeaviateStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -297,6 +298,11 @@ public class BaseStore {
         case Constants.VECTOR_STORE_OPENSEARCH:
 
           baseStore = new OpenSearchStore(storeName, configuration, queryParams, dimension);
+          break;
+
+        case Constants.VECTOR_STORE_QDRANT:
+
+          baseStore = new QdrantStore(storeName, configuration, queryParams, dimension);
           break;
 
         default:

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/store/qdrant/QdrantStore.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/store/qdrant/QdrantStore.java
@@ -27,7 +27,6 @@ public class QdrantStore extends BaseStore {
     JSONObject vectorStoreConfig = config.getJSONObject(Constants.VECTOR_STORE_QDRANT);
     this.host = vectorStoreConfig.getString("QDRANT_HOST");
     this.apiKey = vectorStoreConfig.getString("QDRANT_API_KEY");
-    this.collectionName = vectorStoreConfig.getString("QDRANT_COLLECTION_NAME");
     this.port = vectorStoreConfig.getInt("QDRANT_GRPC_PORT");
     this.useTls = vectorStoreConfig.getBoolean("QDRANT_USE_TLS");
     this.payloadTextKey = vectorStoreConfig.getString("QDRANT_TEXT_KEY");
@@ -38,7 +37,7 @@ public class QdrantStore extends BaseStore {
     return QdrantEmbeddingStore.builder()
         .host(host)
         .apiKey(apiKey)
-        .collectionName(collectionName)
+        .collectionName(storeName)
         .port(port)
         .useTls(useTls)
         .payloadTextKey(payloadTextKey)

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/store/qdrant/QdrantStore.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/store/qdrant/QdrantStore.java
@@ -1,0 +1,47 @@
+package org.mule.extension.mulechain.vectors.internal.store.qdrant;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import org.json.JSONObject;
+import org.mule.extension.mulechain.vectors.internal.config.Configuration;
+import org.mule.extension.mulechain.vectors.internal.constant.Constants;
+import org.mule.extension.mulechain.vectors.internal.helper.parameter.QueryParameters;
+import org.mule.extension.mulechain.vectors.internal.store.BaseStore;
+import org.mule.extension.mulechain.vectors.internal.util.JsonUtils;
+
+public class QdrantStore extends BaseStore {
+
+  private String host;
+  private String collectionName;
+  private String apiKey;
+  private int port;
+  private boolean useTls;
+  private String payloadTextKey;
+
+  public QdrantStore(String storeName, Configuration configuration, QueryParameters queryParams, int dimension) {
+
+    super(storeName, configuration, queryParams, dimension);
+
+    JSONObject config = JsonUtils.readConfigFile(configuration.getConfigFilePath());
+    JSONObject vectorStoreConfig = config.getJSONObject(Constants.VECTOR_STORE_QDRANT);
+    this.host = vectorStoreConfig.getString("QDRANT_HOST");
+    this.apiKey = vectorStoreConfig.getString("QDRANT_API_KEY");
+    this.collectionName = vectorStoreConfig.getString("QDRANT_COLLECTION_NAME");
+    this.port = vectorStoreConfig.getInt("QDRANT_GRPC_PORT");
+    this.useTls = vectorStoreConfig.getBoolean("QDRANT_USE_TLS");
+    this.payloadTextKey = vectorStoreConfig.getString("QDRANT_TEXT_KEY");
+  }
+
+  public EmbeddingStore<TextSegment> buildEmbeddingStore() {
+
+    return QdrantEmbeddingStore.builder()
+        .host(host)
+        .apiKey(apiKey)
+        .collectionName(collectionName)
+        .port(port)
+        .useTls(useTls)
+        .payloadTextKey(payloadTextKey)
+        .build();
+  }
+}

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/store/qdrant/QdrantStore.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/store/qdrant/QdrantStore.java
@@ -1,8 +1,16 @@
 package org.mule.extension.mulechain.vectors.internal.store.qdrant;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.JsonWithInt;
+import io.qdrant.client.grpc.Points;
 import org.json.JSONObject;
 import org.mule.extension.mulechain.vectors.internal.config.Configuration;
 import org.mule.extension.mulechain.vectors.internal.constant.Constants;
@@ -10,37 +18,126 @@ import org.mule.extension.mulechain.vectors.internal.helper.parameter.QueryParam
 import org.mule.extension.mulechain.vectors.internal.store.BaseStore;
 import org.mule.extension.mulechain.vectors.internal.util.JsonUtils;
 
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+
 public class QdrantStore extends BaseStore {
 
-  private String host;
-  private String collectionName;
-  private String apiKey;
-  private int port;
-  private boolean useTls;
-  private String payloadTextKey;
+    private final QdrantClient client;
+    private final String payloadTextKey;
 
-  public QdrantStore(String storeName, Configuration configuration, QueryParameters queryParams, int dimension) {
+    public QdrantStore(String storeName, Configuration configuration, QueryParameters queryParams, int dimension) {
 
-    super(storeName, configuration, queryParams, dimension);
+        super(storeName, configuration, queryParams, dimension);
 
-    JSONObject config = JsonUtils.readConfigFile(configuration.getConfigFilePath());
-    JSONObject vectorStoreConfig = config.getJSONObject(Constants.VECTOR_STORE_QDRANT);
-    this.host = vectorStoreConfig.getString("QDRANT_HOST");
-    this.apiKey = vectorStoreConfig.getString("QDRANT_API_KEY");
-    this.port = vectorStoreConfig.getInt("QDRANT_GRPC_PORT");
-    this.useTls = vectorStoreConfig.getBoolean("QDRANT_USE_TLS");
-    this.payloadTextKey = vectorStoreConfig.getString("QDRANT_TEXT_KEY");
-  }
+        JSONObject config = JsonUtils.readConfigFile(configuration.getConfigFilePath());
+        JSONObject vectorStoreConfig = config.getJSONObject(Constants.VECTOR_STORE_QDRANT);
+        String host = vectorStoreConfig.getString("QDRANT_HOST");
+        String apiKey = vectorStoreConfig.getString("QDRANT_API_KEY");
+        int port = vectorStoreConfig.getInt("QDRANT_GRPC_PORT");
+        boolean useTls = vectorStoreConfig.getBoolean("QDRANT_USE_TLS");
+        this.client = new QdrantClient(QdrantGrpcClient.newBuilder(host, port, useTls).withApiKey(apiKey).build());
+        this.payloadTextKey = vectorStoreConfig.getString("QDRANT_TEXT_KEY");
+    }
 
-  public EmbeddingStore<TextSegment> buildEmbeddingStore() {
+    public EmbeddingStore<TextSegment> buildEmbeddingStore() {
 
-    return QdrantEmbeddingStore.builder()
-        .host(host)
-        .apiKey(apiKey)
-        .collectionName(storeName)
-        .port(port)
-        .useTls(useTls)
-        .payloadTextKey(payloadTextKey)
-        .build();
-  }
+        return QdrantEmbeddingStore.builder()
+                .client(client)
+                .payloadTextKey(payloadTextKey)
+                .build();
+    }
+
+    @Override
+    public JSONObject listSources() {
+        try {
+            // Optional max limit of 100k points.
+            int MAX_POINTS = 10000;
+
+            HashMap<String, JSONObject> sourceObjectMap = new HashMap<String, JSONObject>();
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put(Constants.JSON_KEY_STORE_NAME, storeName);
+
+            boolean keepScrolling = true;
+            Points.PointId nextOffset = null;
+            List<Points.RetrievedPoint> points = new ArrayList<>(MAX_POINTS);
+            while (keepScrolling && points.size() < MAX_POINTS) {
+                Points.ScrollPoints.Builder request = Points.ScrollPoints.newBuilder()
+                        .setCollectionName(storeName)
+                        .setLimit(Math.min(queryParams.embeddingPageSize(), MAX_POINTS - points.size()));
+                if (nextOffset != null) {
+                    request.setOffset(nextOffset);
+                }
+
+                Points.ScrollResponse response = client.scrollAsync(request.build()).get();
+
+                points.addAll(response.getResultList());
+                nextOffset = response.getNextPageOffset();
+                keepScrolling = nextOffset.hasNum() || nextOffset.hasUuid();
+            }
+
+            for (Points.RetrievedPoint point : points) {
+                JSONObject metadataObject = new JSONObject(JsonFactory.toJson(point.getPayloadMap()));
+                JSONObject sourceObject = getSourceObject(metadataObject);
+                addOrUpdateSourceObjectIntoSourceObjectMap(sourceObjectMap, sourceObject);
+            }
+
+            jsonObject.put(Constants.JSON_KEY_SOURCES,
+                    JsonUtils.jsonObjectCollectionToJsonArray(sourceObjectMap.values()));
+            jsonObject.put(Constants.JSON_KEY_SOURCE_COUNT, sourceObjectMap.size());
+
+            return jsonObject;
+        } catch (ExecutionException | InterruptedException | InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
+final class JsonFactory {
+    public static String toJson(Map<String, JsonWithInt.Value> map)
+            throws InvalidProtocolBufferException {
+
+        Struct.Builder structBuilder = Struct.newBuilder();
+        map.forEach((key, value) -> structBuilder.putFields(key, toProtobufValue(value)));
+        return JsonFormat.printer().print(structBuilder.build());
+    }
+
+    private static Value toProtobufValue(io.qdrant.client.grpc.JsonWithInt.Value value) {
+        switch (value.getKindCase()) {
+            case NULL_VALUE:
+                return Value.newBuilder().setNullValueValue(0).build();
+
+            case BOOL_VALUE:
+                return Value.newBuilder().setBoolValue(value.getBoolValue()).build();
+
+            case STRING_VALUE:
+                return Value.newBuilder().setStringValue(value.getStringValue()).build();
+
+            case INTEGER_VALUE:
+                return Value.newBuilder().setNumberValue(value.getIntegerValue()).build();
+
+            case DOUBLE_VALUE:
+                return Value.newBuilder().setNumberValue(value.getDoubleValue()).build();
+
+            case STRUCT_VALUE:
+                Struct.Builder structBuilder = Struct.newBuilder();
+                value.getStructValue()
+                        .getFieldsMap()
+                        .forEach(
+                                (key, val) -> {
+                                    structBuilder.putFields(key, toProtobufValue(val));
+                                });
+                return Value.newBuilder().setStructValue(structBuilder).build();
+
+            case LIST_VALUE:
+                Value.Builder listBuilder = Value.newBuilder();
+                value.getListValue().getValuesList().stream()
+                        .map(JsonFactory::toProtobufValue)
+                        .forEach(listBuilder.getListValueBuilder()::addValues);
+                return listBuilder.build();
+
+            default:
+                throw new IllegalArgumentException("Unsupported payload value type: " + value.getKindCase());
+        }
+    }
 }

--- a/src/main/java/org/mule/extension/mulechain/vectors/internal/store/weaviate/WeaviateStore.java
+++ b/src/main/java/org/mule/extension/mulechain/vectors/internal/store/weaviate/WeaviateStore.java
@@ -1,4 +1,4 @@
-package org.mule.extension.mulechain.vectors.internal.store.weviate;
+package org.mule.extension.mulechain.vectors.internal.store.weaviate;
 
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;


### PR DESCRIPTION
## Description

This PR adds support for Qdrant - https://qdrant.tech/ to be used as a vectorstore in Anypoint Studio. Resolves #37.

This is my first time working with Anypoint Studio. So took while to get around things.

## Usage

To run Qdrant:

```bash
docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
```

You'll find a UI at http://localhost:6333/dashboard. Before adding or retrieving docs, be sure to create a collection as described at https://qdrant.tech/documentation/concepts/collections/#create-a-collection. Store name == collection name.

The Java client uses Qdrant's gRPC interface which is at port 6334.

Here's an example config.

<img width="547" alt="Screenshot 2024-11-20 at 12 35 12 PM" src="https://github.com/user-attachments/assets/17bf4f82-1bbc-4af9-8ecf-ee68eb69702a">


Here's a snip from the [Qdrant UI](https://qdrant.tech/documentation/interfaces/web-ui/) after adding a document.

<img width="1280" alt="Screenshot 2024-11-20 at 9 37 44 AM" src="https://github.com/user-attachments/assets/e248d1d0-c59d-4e55-a82f-9343fce67f95">

