### PR TITLE
Update connector version to 0.5.4 and refine error handling for Azure…

### DIFF
--- a/demo/mule-vectors-connector-azure-demo/pom.xml
+++ b/demo/mule-vectors-connector-azure-demo/pom.xml
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>io.github.mulesoft-ai-chain-project</groupId>
 			<artifactId>mule4-vectors-connector</artifactId>
-			<version>0.5.3</version>
+			<version>0.5.4</version>
 			<classifier>mule-plugin</classifier>
 		</dependency>
 		<dependency>

--- a/demo/mule-vectors-connector-operations-demo/pom.xml
+++ b/demo/mule-vectors-connector-operations-demo/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>io.github.mulesoft-ai-chain-project</groupId>
 	  		<artifactId>mule4-vectors-connector</artifactId>
-    		<version>0.5.3</version>
+    		<version>0.5.4</version>
 			<classifier>mule-plugin</classifier>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-vectors-connector</artifactId>
-    <version>0.5.3</version>
+    <version>0.5.4</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft Vectors Connector - Mule 4</name>
 	<description>MuleSoft Vectors Connector provides access to a broad number of external Vector Stores.</description>

--- a/src/main/java/org/mule/extension/vectors/internal/connection/model/azureopenai/AzureOpenAIModelConnection.java
+++ b/src/main/java/org/mule/extension/vectors/internal/connection/model/azureopenai/AzureOpenAIModelConnection.java
@@ -109,9 +109,9 @@ public class AzureOpenAIModelConnection implements BaseTextModelConnection {
         throw new RuntimeException("Invalid credentials");
       }
       
-      // 404 with DeploymentNotFound is expected since we're using a fake deployment
+      // Either 404 with DeploymentNotFound or 400 with Bad Request is expected since we're using a fake deployment
       // Any other error indicates a problem
-      if (response.getStatusCode() != 404) {
+      if (response.getStatusCode() != 404 && response.getStatusCode() != 400) {
         String errorMsg = String.format("Unexpected response code: %d", response.getStatusCode());
         LOGGER.error(errorMsg);
         throw new RuntimeException(errorMsg);


### PR DESCRIPTION
… OpenAI connection

- Bump version from 0.5.3 to 0.5.4 in  files for main project and demos.
- Adjust error handling logic in  to account for HTTP 400 (Bad Request) as an expected response alongside 404 (DeploymentNotFound).