### PR TITLE
Add support for MongoDB Atlas vector store integration

### DIFF
--- a/src/main/java/org/mule/extension/vectors/internal/helper/OperationValidator.java
+++ b/src/main/java/org/mule/extension/vectors/internal/helper/OperationValidator.java
@@ -89,6 +89,7 @@ public class OperationValidator {
               Constants.VECTOR_STORE_ELASTICSEARCH,
               Constants.VECTOR_STORE_OPENSEARCH,
               Constants.VECTOR_STORE_MILVUS,
+              Constants.VECTOR_STORE_MONGODB_ATLAS,
               Constants.VECTOR_STORE_CHROMA,
               Constants.VECTOR_STORE_PINECONE,
               Constants.VECTOR_STORE_AI_SEARCH,

--- a/src/main/java/org/mule/extension/vectors/internal/store/mongodbatlas/MongoDBAtlasStore.java
+++ b/src/main/java/org/mule/extension/vectors/internal/store/mongodbatlas/MongoDBAtlasStore.java
@@ -70,20 +70,79 @@ public class MongoDBAtlasStore extends BaseStore {
 
   public class RowIterator extends BaseStore.RowIterator {
 
-    private QueryIterator queryIterator;
-    private List<QueryResultsWrapper.RowRecord> currentBatch;
+    private static final String ID_FIELD = "_id";
+    private static final String METADATA_FIELD = "metadata";
+    private static final String TEXT_FIELD = "text";
+    private static final String VECTOR_FIELD = "embedding";
+
+    private final com.mongodb.client.MongoCollection<org.bson.Document> collection;
+    private final int pageSize;
+    private int skip;
+    private List<org.bson.Document> currentBatch;
     private int currentIndex;
+    private boolean noMoreData;
 
     public RowIterator() throws Exception {
-        super();
+      super();
+      this.collection = mongoClient.getDatabase(((MongoDBAtlasStoreConnection)storeConnection).getDatabase())
+        .getCollection(storeName);
+      this.pageSize = queryParams.pageSize();
+      this.skip = 0;
+      this.currentBatch = new ArrayList<>();
+      this.currentIndex = 0;
+      this.noMoreData = false;
+      loadNextBatch();
+    }
+
+    private void loadNextBatch() {
+      currentBatch.clear();
+      currentIndex = 0;
+      List<org.bson.Document> batch = collection.find()
+        .skip(skip)
+        .limit(pageSize)
+        .into(new ArrayList<>());
+      if (batch.isEmpty()) {
+        noMoreData = true;
+      } else {
+        currentBatch.addAll(batch);
+        skip += batch.size();
+      }
     }
 
     @Override
     public boolean hasNext() {
-      return true;
+      if (currentIndex < currentBatch.size()) {
+        return true;
+      } else if (!noMoreData) {
+        loadNextBatch();
+        return currentIndex < currentBatch.size();
+      } else {
+        return false;
+      }
     }
 
     @Override
-    public Row<?> next() { return null; }
+    public Row<?> next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      org.bson.Document doc = currentBatch.get(currentIndex++);
+      String id = doc.get(ID_FIELD).toString();
+      org.bson.Document metadataDoc = doc.get(METADATA_FIELD, org.bson.Document.class);
+      String text = doc.getString(TEXT_FIELD);
+      float[] vector = null;
+      if (queryParams.retrieveEmbeddings() && doc.containsKey(VECTOR_FIELD)) {
+        List<Double> vectorList = doc.getList(VECTOR_FIELD, Double.class);
+        vector = new float[vectorList.size()];
+        for (int i = 0; i < vectorList.size(); i++) {
+          vector[i] = vectorList.get(i).floatValue();
+        }
+      }
+      return new Row<>(
+        id,
+        vector != null ? new Embedding(vector) : null,
+        new TextSegment(text, Metadata.from(metadataDoc))
+      );
+    }
   }
 }


### PR DESCRIPTION
- #159  
  - Update `OperationValidator` to include `VECTOR_STORE_MONGODB_ATLAS` in the supported vector stores list.
  - Implement `RowIterator` in `MongoDBAtlasStore` to efficiently paginate, fetch, and process documents from MongoDB collections.
  - Ensure proper handling of metadata, embeddings, and text data during row iteration.