### PR TITLE
Feature/168 remove LangChain4j dependencies for storage

### DIFF
--- a/demo/mule-vectors-connector-azure-demo/pom.xml
+++ b/demo/mule-vectors-connector-azure-demo/pom.xml
@@ -14,7 +14,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<app.runtime>4.9.0</app.runtime>
 		<mule.maven.plugin.version>4.3.0</mule.maven.plugin.version>
-		<langchain4jVersion>1.0.0-beta5</langchain4jVersion>
+		<langchain4jVersion>1.0.0-beta6</langchain4jVersion>
 	</properties>
 
 	<build>
@@ -35,9 +35,6 @@
 							<groupId>io.github.mulesoft-ai-chain-project</groupId>
 							<artifactId>mule4-vectors-connector</artifactId>
 							<additionalDependencies>
-								<!-- Storage Dependencies (Optionals) -->
-								
-								<!-- Vector Store Dependencies (Optionals) -->
 								<!-- BEGIN: Azure AI Search Dependency -->
 								<dependency>
 									<groupId>dev.langchain4j</groupId>
@@ -69,7 +66,7 @@
 		<dependency>
 			<groupId>io.github.mulesoft-ai-chain-project</groupId>
 			<artifactId>mule4-vectors-connector</artifactId>
-			<version>0.5.30</version>
+			<version>0.5.40</version>
 			<classifier>mule-plugin</classifier>
 		</dependency>
 		<dependency>

--- a/demo/mule-vectors-connector-operations-demo/pom.xml
+++ b/demo/mule-vectors-connector-operations-demo/pom.xml
@@ -14,7 +14,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<app.runtime>4.9.0</app.runtime>
 		<mule.maven.plugin.version>4.3.0</mule.maven.plugin.version>
-		<langchain4jVersion>1.0.0-beta5</langchain4jVersion>
+		<langchain4jVersion>1.0.0-beta6</langchain4jVersion>
 	</properties>
 
 	<build>
@@ -35,9 +35,6 @@
 							<groupId>io.github.mulesoft-ai-chain-project</groupId>
 							<artifactId>mule4-vectors-connector</artifactId>
 							<additionalDependencies>
-							
-								<!-- Storage Dependencies (Optionals) -->
-								
 								<!-- Vector Store Dependencies (Optionals) -->
 								<!-- BEGIN: PGVector Dependency -->
 								<dependency> 
@@ -71,7 +68,7 @@
 		<dependency>
 			<groupId>io.github.mulesoft-ai-chain-project</groupId>
 	  		<artifactId>mule4-vectors-connector</artifactId>
-    		<version>0.5.30</version>
+    		<version>0.5.40</version>
 			<classifier>mule-plugin</classifier>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-vectors-connector</artifactId>
-    <version>0.5.32-SNAPSHOT</version>
+    <version>0.5.40</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft Vectors Connector - Mule 4</name>
 	<description>MuleSoft Vectors Connector provides access to a broad number of external Vector Stores.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-vectors-connector</artifactId>
-    <version>0.5.31-SNAPSHOT</version>
+    <version>0.5.32-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft Vectors Connector - Mule 4</name>
 	<description>MuleSoft Vectors Connector provides access to a broad number of external Vector Stores.</description>
@@ -261,8 +261,15 @@
 
 		<!-- Storage Dependencies (Optionals) -->
 		<dependency>
-			<groupId>dev.langchain4j</groupId>
-			<artifactId>langchain4j-document-loader-azure-storage-blob</artifactId>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-storage-blob</artifactId>
+			<version>12.30.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-storage-common</artifactId>
+			<version>12.29.0</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-vectors-connector</artifactId>
-    <version>0.5.30</version>
+    <version>0.5.31-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft Vectors Connector - Mule 4</name>
 	<description>MuleSoft Vectors Connector provides access to a broad number of external Vector Stores.</description>
@@ -267,8 +267,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>dev.langchain4j</groupId>
-			<artifactId>langchain4j-document-loader-amazon-s3</artifactId>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>2.31.6</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -266,12 +266,6 @@
 			<version>12.30.0</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.azure</groupId>
-			<artifactId>azure-storage-common</artifactId>
-			<version>12.29.0</version>
-			<scope>provided</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -281,8 +281,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>dev.langchain4j</groupId>
-			<artifactId>langchain4j-document-loader-google-cloud-storage</artifactId>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-storage</artifactId>
+			<version>2.43.0</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/org/mule/extension/vectors/internal/connection/storage/amazons3/AmazonS3StorageConnection.java
+++ b/src/main/java/org/mule/extension/vectors/internal/connection/storage/amazons3/AmazonS3StorageConnection.java
@@ -1,11 +1,19 @@
 package org.mule.extension.vectors.internal.connection.storage.amazons3;
 
+import dev.langchain4j.data.document.BlankDocumentException;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
 import org.mule.extension.vectors.internal.connection.storage.BaseStorageConnection;
 import org.mule.extension.vectors.internal.constant.Constants;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.lang.String.format;
 
 public class AmazonS3StorageConnection implements BaseStorageConnection {
 
@@ -65,5 +73,25 @@ public class AmazonS3StorageConnection implements BaseStorageConnection {
 
     this.s3Client.listBuckets();
     return true;
+  }
+
+  public Document loadDocument(String bucket, String key, DocumentParser parser) {
+    try {
+      GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+          .bucket(ensureNotBlank(bucket, "bucket"))
+          .key(ensureNotBlank(key, "key"))
+          .build();
+      ResponseInputStream<GetObjectResponse> inputStream = s3Client.getObject(getObjectRequest);
+      Document document = parser.parse(inputStream);
+      document.metadata().put(Constants.METADATA_KEY_SOURCE, format("s3://%s/%s", bucket, key));
+      return document;
+
+    } catch (S3Exception e) {
+      throw new RuntimeException(e);
+    } catch (BlankDocumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load document", e);
+    }
   }
 }

--- a/src/main/java/org/mule/extension/vectors/internal/connection/storage/amazons3/AmazonS3StorageConnectionProvider.java
+++ b/src/main/java/org/mule/extension/vectors/internal/connection/storage/amazons3/AmazonS3StorageConnectionProvider.java
@@ -5,12 +5,22 @@ import org.mule.extension.vectors.internal.connection.storage.BaseStorageConnect
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.connection.ConnectionValidationResult;
 import org.mule.runtime.extension.api.annotation.Alias;
+
+import org.mule.runtime.extension.api.annotation.ExternalLib;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
 
+import static org.mule.runtime.api.meta.ExternalLibraryType.DEPENDENCY;
+
 @Alias("amazonS3")
 @DisplayName("Amazon S3")
+@ExternalLib(name = "Amazon AWS SDK",
+    type=DEPENDENCY,
+    description = "Amazon AWS SDK",
+    nameRegexpMatcher = "(.*)\\.jar",
+    requiredClassName = "software.amazon.awssdk.services.s3.S3Client",
+    coordinates = "software.amazon.awssdk:s3:2.31.6")
 public class AmazonS3StorageConnectionProvider extends BaseStorageConnectionProvider {
 
   @ParameterGroup(name = Placement.CONNECTION_TAB)

--- a/src/main/java/org/mule/extension/vectors/internal/connection/storage/azureblob/AzureBlobStorageConnection.java
+++ b/src/main/java/org/mule/extension/vectors/internal/connection/storage/azureblob/AzureBlobStorageConnection.java
@@ -1,10 +1,18 @@
 package org.mule.extension.vectors.internal.connection.storage.azureblob;
 
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.specialized.BlobInputStream;
 import com.azure.storage.common.StorageSharedKeyCredential;
+import dev.langchain4j.data.document.BlankDocumentException;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
 import org.mule.extension.vectors.internal.connection.storage.BaseStorageConnection;
 import org.mule.extension.vectors.internal.constant.Constants;
+
+import static java.lang.String.format;
 
 public class AzureBlobStorageConnection implements BaseStorageConnection {
 
@@ -52,5 +60,26 @@ public class AzureBlobStorageConnection implements BaseStorageConnection {
 
     this.blobServiceClient.listBlobContainers();
     return true;
+  }
+
+  public Document loadDocument(String containerName, String blobName, DocumentParser parser) {
+
+    BlobClient blobClient = blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
+    BlobProperties properties = blobClient.getProperties();
+    BlobInputStream blobInputStream = blobClient.openInputStream();
+    try {
+
+      Document document = parser.parse(blobInputStream);
+      document.metadata().put(Constants.METADATA_KEY_SOURCE, format("https://%s.blob.core.windows.net/%s/%s", azureName, containerName, blobName));
+      document.metadata().put("azure_storage_blob_creation_time", String.valueOf(properties.getCreationTime()));
+      document.metadata().put("azure_storage_blob_last_modified", String.valueOf(properties.getLastModified()));
+      document.metadata().put("azure_storage_blob_content_length", String.valueOf(properties.getBlobSize()));
+      return document;
+
+    } catch (BlankDocumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load document", e);
+    }
   }
 }

--- a/src/main/java/org/mule/extension/vectors/internal/connection/storage/azureblob/AzureBlobStorageConnectionProvider.java
+++ b/src/main/java/org/mule/extension/vectors/internal/connection/storage/azureblob/AzureBlobStorageConnectionProvider.java
@@ -5,12 +5,21 @@ import org.mule.extension.vectors.internal.connection.storage.BaseStorageConnect
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.connection.ConnectionValidationResult;
 import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.ExternalLib;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
 
+import static org.mule.runtime.api.meta.ExternalLibraryType.DEPENDENCY;
+
 @Alias("azureBlob")
 @DisplayName("Azure Blob")
+@ExternalLib(name = "Azure Blob Storage",
+    type=DEPENDENCY,
+    description = "Azure Blob Storage",
+    nameRegexpMatcher = "(.*)\\.jar",
+    requiredClassName = "com.azure.storage.blob.BlobClient",
+    coordinates = "com.azure:azure-storage-blob:12.30.0")
 public class AzureBlobStorageConnectionProvider extends BaseStorageConnectionProvider {
 
   @ParameterGroup(name = Placement.CONNECTION_TAB)

--- a/src/main/java/org/mule/extension/vectors/internal/connection/storage/gcs/GoogleCloudStorageConnectionProvider.java
+++ b/src/main/java/org/mule/extension/vectors/internal/connection/storage/gcs/GoogleCloudStorageConnectionProvider.java
@@ -5,12 +5,21 @@ import org.mule.extension.vectors.internal.connection.storage.BaseStorageConnect
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.connection.ConnectionValidationResult;
 import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.ExternalLib;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
 
+import static org.mule.runtime.api.meta.ExternalLibraryType.DEPENDENCY;
+
 @Alias("googleCloudStorage")
 @DisplayName("Google Cloud Storage")
+@ExternalLib(name = "Google Cloud Storage",
+    type=DEPENDENCY,
+    description = "Google Cloud Storage",
+    nameRegexpMatcher = "(.*)\\.jar",
+    requiredClassName = "com.google.cloud.storage.Storage",
+    coordinates = "com.google.cloud:google-cloud-storage:2.43.0")
 public class GoogleCloudStorageConnectionProvider extends BaseStorageConnectionProvider {
 
     @ParameterGroup(name = Placement.CONNECTION_TAB)

--- a/src/main/java/org/mule/extension/vectors/internal/storage/amazons3/AmazonS3Storage.java
+++ b/src/main/java/org/mule/extension/vectors/internal/storage/amazons3/AmazonS3Storage.java
@@ -13,8 +13,6 @@ import org.mule.extension.vectors.internal.util.MetadataUtils;
 import org.mule.runtime.extension.api.exception.ModuleException;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.regions.Region;
-import dev.langchain4j.data.document.loader.amazon.s3.AmazonS3DocumentLoader;
-import dev.langchain4j.data.document.loader.amazon.s3.AwsCredentials;
 import dev.langchain4j.data.image.Image;
 
 import java.net.URLEncoder;
@@ -38,21 +36,6 @@ public class AmazonS3Storage extends BaseStorage {
     private final String awsRegion;
 
     private String continuationToken = null;
-
-    private AwsCredentials getCredentials() {
-        return new AwsCredentials(awsAccessKeyId, awsSecretAccessKey);
-    }
-
-    private AmazonS3DocumentLoader loader;
-
-    private AmazonS3DocumentLoader getLoader() {
-
-        if(loader == null) {
-
-            loader = new AmazonS3DocumentLoader(s3Client);
-        }
-        return loader;
-    }
 
     private S3Client s3Client;
 
@@ -118,7 +101,7 @@ public class AmazonS3Storage extends BaseStorage {
     public Document getSingleDocument() {
 
         LOGGER.debug("S3 URL: " + contextPath);
-        Document document = getLoader().loadDocument(getAWSS3Bucket(), getAWSS3ObjectKey(), documentParser);
+        Document document = ((AmazonS3StorageConnection)storageConnection).loadDocument(getAWSS3Bucket(), getAWSS3ObjectKey(), documentParser);
         MetadataUtils.addMetadataToDocument(document, fileType, getAWSS3ObjectKey());
         return document;
     }
@@ -238,7 +221,7 @@ public class AmazonS3Storage extends BaseStorage {
             LOGGER.debug("AWS S3 Object Key: " + object.key());
             Document document;
             try {
-                document = getLoader().loadDocument(getAWSS3Bucket(), object.key(), documentParser);
+                document = ((AmazonS3StorageConnection)storageConnection).loadDocument(getAWSS3Bucket(), object.key(), documentParser);
             } catch(BlankDocumentException bde) {
 
                 LOGGER.warn(String.format("BlankDocumentException: Error while parsing document %s.", contextPath));

--- a/src/main/java/org/mule/extension/vectors/internal/storage/azureblob/AzureBlobStorage.java
+++ b/src/main/java/org/mule/extension/vectors/internal/storage/azureblob/AzureBlobStorage.java
@@ -9,7 +9,6 @@ import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import dev.langchain4j.data.document.BlankDocumentException;
-import dev.langchain4j.data.document.loader.azure.storage.blob.AzureBlobStorageDocumentLoader;
 import dev.langchain4j.data.image.Image;
 
 import java.io.ByteArrayOutputStream;
@@ -54,17 +53,6 @@ public class AzureBlobStorage extends BaseStorage {
                 .buildClient();
         }
         return this.blobServiceClient;
-    }
-
-    private AzureBlobStorageDocumentLoader loader;
-
-    private AzureBlobStorageDocumentLoader getLoader() {
-
-        if(this.loader == null) {
-
-            this.loader = new AzureBlobStorageDocumentLoader(getBlobServiceClient());
-        }
-        return this.loader;
     }
 
     private Iterator<BlobItem> blobIterator;
@@ -124,7 +112,7 @@ public class AzureBlobStorage extends BaseStorage {
         String containerName = getContainerName();
         String blobName = getBlobName();
         LOGGER.debug("Blob name: " + blobName);
-        Document document = getLoader().loadDocument(containerName, blobName, documentParser);
+        Document document = ((AzureBlobStorageConnection)storageConnection).loadDocument(containerName, blobName, documentParser);
         MetadataUtils.addMetadataToDocument(document, fileType, blobName);
         return document;
     }
@@ -220,7 +208,7 @@ public class AzureBlobStorage extends BaseStorage {
             LOGGER.debug("Blob name: " + blobItem.getName());
             Document document;
             try {
-                document = getLoader().loadDocument(contextPath, blobItem.getName(), documentParser);
+                document = ((AzureBlobStorageConnection)storageConnection).loadDocument(contextPath, blobItem.getName(), documentParser);
             } catch(BlankDocumentException bde) {
 
                 LOGGER.warn(String.format("BlankDocumentException: Error while parsing document %s.", contextPath));


### PR DESCRIPTION
Removed LangChain4J dependencies for cloud storage services. No we fully support shared libraries approach for Storage.

<img width="618" alt="image" src="https://github.com/user-attachments/assets/4847764f-36e2-41ff-b532-0edb8f194e14" />

<img width="606" alt="image" src="https://github.com/user-attachments/assets/b8480337-1db8-4e7d-acfc-83994e939236" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/6cea1c2b-0a13-400f-a7ad-0613e82f5599" />
