### PR TITLE
feat: enhance file loading to include metadata and mime type 

### DIFF
--- a/src/main/java/org/mule/extension/vectors/api/metadata/StorageResponseAttributes.java
+++ b/src/main/java/org/mule/extension/vectors/api/metadata/StorageResponseAttributes.java
@@ -24,6 +24,10 @@ public class StorageResponseAttributes implements Serializable {
 
   private final String fileName;
 
+  private final String mimeType;
+
+  private final Map<String, Object> metadata;
+
   /**
    * Additional attributes not explicitly defined as fields in this class.
    */
@@ -41,6 +45,8 @@ public class StorageResponseAttributes implements Serializable {
 
     this.path = requestAttributes.containsKey("path") ? (String) requestAttributes.remove("path") : null;
     this.fileName = requestAttributes.containsKey("fileName") ? (String) requestAttributes.remove("fileName") : null;
+    this.mimeType = requestAttributes.containsKey("mimeType") ? (String) requestAttributes.remove("mimeType") : null;
+    this.metadata = requestAttributes.containsKey("metadata") ? (Map<String, Object>) requestAttributes.remove("metadata") : null;
     this.otherAttributes = requestAttributes;
   }
 
@@ -51,6 +57,10 @@ public class StorageResponseAttributes implements Serializable {
   public String getFileName() {
     return fileName;
   }
+
+  public String getMimeType() { return mimeType; }
+
+  public Map<String, Object> getMetadata() { return metadata; }
 
   /**
    * Gets additional attributes of the file.

--- a/src/main/java/org/mule/extension/vectors/internal/operation/StorageOperations.java
+++ b/src/main/java/org/mule/extension/vectors/internal/operation/StorageOperations.java
@@ -63,6 +63,8 @@ public class StorageOperations {
           new HashMap<String, Object>() {{
             put("path", file.getPath());
             put("fileName", file.getFileName());
+            put("mimeType", file.getMimeType());
+            put("metadata", file.getMetadata());
           }});
     } catch (ModuleException me) {
       throw me;

--- a/src/main/java/org/mule/extension/vectors/internal/pagination/FilePagingProvider.java
+++ b/src/main/java/org/mule/extension/vectors/internal/pagination/FilePagingProvider.java
@@ -48,6 +48,8 @@ public class FilePagingProvider implements PagingProvider<BaseStorageConnection,
             new HashMap<String, Object>() {{
               put("path", file.getPath());
               put("fileName", file.getFileName());
+              put("mimeType", file.getMimeType());
+              put("metadata", file.getMetadata());
             }},
             streamingHelper
         );

--- a/src/main/java/org/mule/extension/vectors/internal/service/storage/AzureBlobStorageService.java
+++ b/src/main/java/org/mule/extension/vectors/internal/service/storage/AzureBlobStorageService.java
@@ -1,12 +1,18 @@
 package org.mule.extension.vectors.internal.service.storage;
 
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobProperties;
+import org.mule.extension.vectors.internal.constant.Constants;
 import org.mule.extension.vectors.internal.storage.azureblob.AzureBlobStorage;
 import org.mule.extension.vectors.internal.storage.FileIterator;
 import org.mule.extension.vectors.internal.data.file.File;
 import org.mule.extension.vectors.internal.storage.azureblob.AzureBlobFileIterator;
 import com.azure.storage.blob.models.BlobItem;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+
+import static java.lang.String.format;
 
 public class AzureBlobStorageService implements StorageService {
     private final AzureBlobStorage azureClient;
@@ -20,8 +26,17 @@ public class AzureBlobStorageService implements StorageService {
         // Assume azureName is available from the client
         String container = AzureBlobStorage.parseContainer(path, azureClient.azureName);
         String blobName = AzureBlobStorage.parseBlobName(path, azureClient.azureName);
-        InputStream content = azureClient.loadFile(container, blobName);
-        return new File(content, container + "/" + blobName, blobName);
+
+        BlobClient blobClient = azureClient.loadFile(container, blobName);
+        BlobProperties properties = blobClient.getProperties();
+        InputStream content = blobClient.openInputStream();
+        HashMap<String, Object> metadata = new HashMap(){{
+            put(Constants.METADATA_KEY_SOURCE, format("https://%s.blob.core.windows.net/%s/%s", azureClient.azureName, container, blobName));
+            put("azure_storage_blob_creation_time", String.valueOf(properties.getCreationTime()));
+            put("azure_storage_blob_last_modified", String.valueOf(properties.getLastModified()));
+            put("azure_storage_blob_content_length", String.valueOf(properties.getBlobSize()));
+        }};
+        return new File(content, container + "/" + blobName, blobName, properties.getContentType(), metadata);
     }
 
     @Override
@@ -31,4 +46,4 @@ public class AzureBlobStorageService implements StorageService {
         List<BlobItem> objects = azureClient.listFiles(container, prefix);
         return new AzureBlobFileIterator(azureClient, container, objects);
     }
-} 
+}

--- a/src/main/java/org/mule/extension/vectors/internal/service/storage/GoogleCloudStorageService.java
+++ b/src/main/java/org/mule/extension/vectors/internal/service/storage/GoogleCloudStorageService.java
@@ -1,11 +1,14 @@
 package org.mule.extension.vectors.internal.service.storage;
 
+import org.mule.extension.vectors.internal.constant.Constants;
 import org.mule.extension.vectors.internal.storage.gcs.GoogleCloudStorage;
 import org.mule.extension.vectors.internal.storage.FileIterator;
 import org.mule.extension.vectors.internal.data.file.File;
 import org.mule.extension.vectors.internal.storage.gcs.GoogleCloudFileIterator;
 import com.google.cloud.storage.Blob;
 import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.util.HashMap;
 import java.util.List;
 
 public class GoogleCloudStorageService implements StorageService {
@@ -20,8 +23,18 @@ public class GoogleCloudStorageService implements StorageService {
         String[] bucketAndObject = GoogleCloudStorage.parseContextPath(path);
         String bucket = bucketAndObject[0];
         String objectName = bucketAndObject[1];
-        InputStream content = gcsClient.loadFile(bucket, objectName);
-        return new File(content, bucket + "/" + objectName, objectName);
+        Blob blob = gcsClient.loadFile(bucket, objectName);
+        InputStream content = Channels.newInputStream(blob.reader());
+        HashMap<String, Object> metadata = new HashMap(){{
+            put(Constants.METADATA_KEY_SOURCE, "gs://" + blob.getBucket() + "/" + blob.getName());
+            put("bucket", blob.getBucket());
+            put("name", blob.getName());
+            put("contentType", blob.getContentType());
+            put("size", blob.getSize());
+            put("createTime", blob.getCreateTimeOffsetDateTime().toString());
+            put("updateTime", blob.getUpdateTimeOffsetDateTime().toString());
+        }};
+        return new File(content, bucket + "/" + objectName, objectName, blob.getContentType(), metadata);
     }
 
     @Override

--- a/src/main/java/org/mule/extension/vectors/internal/service/storage/LocalStorageService.java
+++ b/src/main/java/org/mule/extension/vectors/internal/service/storage/LocalStorageService.java
@@ -4,7 +4,11 @@ import org.mule.extension.vectors.internal.storage.local.LocalStorage;
 import org.mule.extension.vectors.internal.storage.FileIterator;
 import org.mule.extension.vectors.internal.data.file.File;
 import org.mule.extension.vectors.internal.storage.local.LocalFileIterator;
+import org.mule.extension.vectors.internal.util.Utils;
+
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -20,7 +24,18 @@ public class LocalStorageService implements StorageService {
     public File getFile(String path) {
         Path filePath = Paths.get(path);
         InputStream content = localClient.loadFile(filePath);
-        return new File(content, path, LocalStorage.parseFileName(path));
+        String mimeType = null;
+        try {
+            mimeType = Files.probeContentType(filePath);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            // Fallback if mimeType is null
+            if (mimeType == null) {
+                mimeType = Utils.getMimeTypeFallback(filePath);
+            }
+        }
+        return new File(content, path, LocalStorage.parseFileName(path), mimeType);
     }
 
     @Override

--- a/src/main/java/org/mule/extension/vectors/internal/storage/amazons3/AmazonS3Storage.java
+++ b/src/main/java/org/mule/extension/vectors/internal/storage/amazons3/AmazonS3Storage.java
@@ -5,11 +5,9 @@ import org.mule.extension.vectors.internal.connection.storage.amazons3.AmazonS3S
 import org.mule.extension.vectors.internal.data.file.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
-import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.InputStream;
 import java.util.List;
@@ -29,7 +27,7 @@ public class AmazonS3Storage {
         this.s3Client = amazonS3StorageConnection.getS3Client();
     }
 
-    public InputStream loadFile(String bucket, String key) {
+    public ResponseInputStream<GetObjectResponse> loadFile(String bucket, String key) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)

--- a/src/main/java/org/mule/extension/vectors/internal/storage/azureblob/AzureBlobFileIterator.java
+++ b/src/main/java/org/mule/extension/vectors/internal/storage/azureblob/AzureBlobFileIterator.java
@@ -1,11 +1,17 @@
 package org.mule.extension.vectors.internal.storage.azureblob;
 
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobProperties;
+import org.mule.extension.vectors.internal.constant.Constants;
 import org.mule.extension.vectors.internal.storage.FileIterator;
 import org.mule.extension.vectors.internal.data.file.File;
 import com.azure.storage.blob.models.BlobItem;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+
+import static java.lang.String.format;
 
 public class AzureBlobFileIterator implements FileIterator {
     private final AzureBlobStorage azureClient;
@@ -28,8 +34,16 @@ public class AzureBlobFileIterator implements FileIterator {
         while (blobIterator.hasNext()) {
             BlobItem blobItem = blobIterator.next();
             // Optionally skip folders or zero-size blobs if needed
-            InputStream content = azureClient.loadFile(container, blobItem.getName());
-            return new File(content, container + "/" + blobItem.getName(), blobItem.getName());
+            BlobClient blobClient = azureClient.loadFile(container, blobItem.getName());
+            BlobProperties properties = blobClient.getProperties();
+            InputStream content = blobClient.openInputStream();
+            HashMap<String, Object> metadata = new HashMap(){{
+                put(Constants.METADATA_KEY_SOURCE, format("https://%s.blob.core.windows.net/%s/%s", azureClient.azureName, container, blobItem.getName()));
+                put("azure_storage_blob_creation_time", String.valueOf(properties.getCreationTime()));
+                put("azure_storage_blob_last_modified", String.valueOf(properties.getLastModified()));
+                put("azure_storage_blob_content_length", String.valueOf(properties.getBlobSize()));
+            }};
+            return new File(content, container + "/" + blobItem.getName(), blobItem.getName(), properties.getContentType(), metadata);
         }
         return null;
     }

--- a/src/main/java/org/mule/extension/vectors/internal/storage/azureblob/AzureBlobStorage.java
+++ b/src/main/java/org/mule/extension/vectors/internal/storage/azureblob/AzureBlobStorage.java
@@ -3,12 +3,9 @@ package org.mule.extension.vectors.internal.storage.azureblob;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobItem;
-import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.ListBlobsOptions;
-import com.azure.storage.blob.specialized.BlobInputStream;
 import org.mule.extension.vectors.internal.config.StorageConfiguration;
 import org.mule.extension.vectors.internal.connection.storage.azureblob.AzureBlobStorageConnection;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -24,11 +21,9 @@ public class AzureBlobStorage {
         this.blobServiceClient = azureBlobStorageConnection.getBlobServiceClient();
     }
 
-    public InputStream loadFile(String containerName, String blobName) {
+    public BlobClient loadFile(String containerName, String blobName) {
         BlobClient blobClient = blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
-        BlobProperties properties = blobClient.getProperties();
-        BlobInputStream blobInputStream = blobClient.openInputStream();
-        return blobInputStream;
+        return blobClient;
     }
 
     public List<BlobItem> listFiles(String containerName, String prefix) {

--- a/src/main/java/org/mule/extension/vectors/internal/storage/gcs/GoogleCloudFileIterator.java
+++ b/src/main/java/org/mule/extension/vectors/internal/storage/gcs/GoogleCloudFileIterator.java
@@ -1,9 +1,12 @@
 package org.mule.extension.vectors.internal.storage.gcs;
 
+import org.mule.extension.vectors.internal.constant.Constants;
 import org.mule.extension.vectors.internal.storage.FileIterator;
 import org.mule.extension.vectors.internal.data.file.File;
 import com.google.cloud.storage.Blob;
 import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
@@ -31,8 +34,17 @@ public class GoogleCloudFileIterator implements FileIterator {
                 // Skip folders
                 continue;
             }
-            InputStream content = gcsClient.loadFile(bucket, blob.getName());
-            return new File(content, bucket + "/" + blob.getName(), blob.getName());
+            InputStream content = Channels.newInputStream(blob.reader());
+            HashMap<String, Object> metadata = new HashMap(){{
+                put(Constants.METADATA_KEY_SOURCE, "gs://" + blob.getBucket() + "/" + blob.getName());
+                put("bucket", blob.getBucket());
+                put("name", blob.getName());
+                put("contentType", blob.getContentType());
+                put("size", blob.getSize());
+                put("createTime", blob.getCreateTimeOffsetDateTime().toString());
+                put("updateTime", blob.getUpdateTimeOffsetDateTime().toString());
+            }};
+            return new File(content, bucket + "/" + blob.getName(), blob.getName(), blob.getContentType(), metadata);
         }
         return null;
     }

--- a/src/main/java/org/mule/extension/vectors/internal/storage/gcs/GoogleCloudStorage.java
+++ b/src/main/java/org/mule/extension/vectors/internal/storage/gcs/GoogleCloudStorage.java
@@ -37,13 +37,13 @@ public class GoogleCloudStorage {
         this.storageService = googleCloudStorageConnection.getStorageService();
     }
 
-    public InputStream loadFile(String bucket, String objectName) {
+    public Blob loadFile(String bucket, String objectName) {
         Blob blob = this.storageService.get(bucket, objectName);
         if (blob == null) {
             throw new IllegalArgumentException("Object gs://" + bucket + "/" + objectName + " couldn't be found.");
         }
         try {
-            return Channels.newInputStream(blob.reader());
+            return blob;
         } catch (Exception e) {
             throw new RuntimeException("Failed to load document", e);
         }


### PR DESCRIPTION
feat: enhance file loading to include metadata and mime type for Azure Blob, GCS, S3 and local storage.

Fill free to review the code as you prefer.

Unfortunately after merging your changes in develop, storage munit tests are no more working. You can test them with `mvn clean verify -Dmunit.test=test-document-operations.xml`